### PR TITLE
Add img argument to get_

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * added browse_phylopic function (#60)
 * added preview argument to get_phylopic (#59)
 * switched to {maps} package in base R advanced vignette
+* added img argument to get_uuid and get_attribution
 
 # rphylopic 1.1.1
 

--- a/R/get_attribution.R
+++ b/R/get_attribution.R
@@ -5,6 +5,9 @@
 #'
 #' @param uuid \code{character}. A vector of valid uuid(s) for PhyloPic 
 #'   silhouette(s) such as that returned by [get_uuid()] or [pick_phylopic()].
+#' @param img A [Picture][grImport2::Picture-class] or png array object, e.g.,
+#'   from using [get_phylopic()]. If supplied, `uuid` is ignored. Defaults to 
+#'   NULL.
 #' @param text \code{logical}. Should attribution information be returned as 
 #' a text paragraph? Defaults to `FALSE`.
 #'
@@ -27,10 +30,17 @@
 #' uuids <- get_uuid(name = "Scleractinia", n = 5)
 #' # Get attribution data for uuids
 #' get_attribution(uuid = uuids, text = TRUE)
-get_attribution <- function(uuid = NULL, text = FALSE) {
+get_attribution <- function(uuid = NULL, img = NULL, text = FALSE) {
+  # Handle img -----------------------------------------------------------
+  if (!is.null(img)) {
+    if (is.null(attr(img, "uuid"))) {
+      stop("uuid not available. Check `img` is from get_phylopic.")
+    }
+    uuid <- attr(img, "uuid")
+  }
   # Error handling -------------------------------------------------------
   if (is.null(uuid)) {
-    stop("A `uuid` is required.")
+    stop("A `uuid` or `img` is required.")
   }
   if (!is.character(uuid)) {
     stop("`uuid` should be of class character.")
@@ -38,7 +48,6 @@ get_attribution <- function(uuid = NULL, text = FALSE) {
   if (!is.logical(text)) {
     stop("`text` should be of class logical.")
   }
-
   # Get licenses ---------------------------------------------------------
   links <- c("https://creativecommons.org/publicdomain/zero/1.0/",
              "https://creativecommons.org/publicdomain/mark/1.0/",

--- a/R/get_attribution.R
+++ b/R/get_attribution.R
@@ -5,9 +5,9 @@
 #'
 #' @param uuid \code{character}. A vector of valid uuid(s) for PhyloPic 
 #'   silhouette(s) such as that returned by [get_uuid()] or [pick_phylopic()].
-#' @param img A [Picture][grImport2::Picture-class] or png array object, e.g.,
-#'   from using [get_phylopic()]. If supplied, `uuid` is ignored. Defaults to 
-#'   NULL.
+#' @param img A [Picture][grImport2::Picture-class] or png array object from 
+#'   [get_phylopic()]. A list of these objects can also be supplied. If `img`
+#'   is supplied, `uuid` is ignored. Defaults to NULL.
 #' @param text \code{logical}. Should attribution information be returned as 
 #' a text paragraph? Defaults to `FALSE`.
 #'
@@ -33,10 +33,14 @@
 get_attribution <- function(uuid = NULL, img = NULL, text = FALSE) {
   # Handle img -----------------------------------------------------------
   if (!is.null(img)) {
-    if (is.null(attr(img, "uuid"))) {
+    if (is.list(img)) {
+      uuid <- sapply(img, function(x) attr(x, "uuid"))
+    } else {
+      uuid <- attr(img, "uuid")
+    }
+    if (any(is.null(uuid))) {
       stop("uuid not available. Check `img` is from get_phylopic.")
     }
-    uuid <- attr(img, "uuid")
   }
   # Error handling -------------------------------------------------------
   if (is.null(uuid)) {

--- a/R/get_uuid.R
+++ b/R/get_uuid.R
@@ -7,9 +7,9 @@
 #' @param name \code{character}. A taxonomic name. Various taxonomic levels
 #'   are supported (e.g. species, genus, family). NULL can also be supplied
 #'   which will skip the taxonomic filtering of the PhyloPic database.
-#' @param img A [Picture][grImport2::Picture-class] or png array object, e.g.,
-#'   from using [get_phylopic()]. If supplied, `name` and `n` are ignored. 
-#'   Defaults to NULL.
+#' @param img A [Picture][grImport2::Picture-class] or png array object from 
+#'   [get_phylopic()]. A list of these objects can also be supplied. If `img`
+#'   is supplied, `name` and `n` are ignored. Defaults to NULL.
 #' @param n \code{numeric}. How many uuids should be returned? Depending on
 #'   the requested `name`, multiple silhouettes might exist. If `n` exceeds
 #'   the number of available images, all available uuids will be returned.
@@ -32,13 +32,20 @@
 get_uuid <- function(name = NULL, img = NULL, n = 1, url = FALSE) {
   # Handle img -----------------------------------------------------------
   if (!is.null(img)) {
-    if (is.null(attr(img, "uuid"))) {
+    if (is.list(img)) {
+      uuid <- sapply(img, function(x) attr(x, "uuid"))
+    } else {
+      uuid <- attr(img, "uuid")
+    }
+    if (any(is.null(uuid))) {
       stop("uuid not available. Check `img` is from get_phylopic.")
     }
     if (url) {
-      uuid <- attr(img, "url")
-    } else {
-      uuid <- attr(img, "uuid")
+      if (is.list(img)) {
+        uuid <- sapply(img, function(x) attr(x, "url"))
+      } else {
+        uuid <- attr(img, "url")
+      }
     }
     return(uuid)
   }

--- a/R/get_uuid.R
+++ b/R/get_uuid.R
@@ -7,6 +7,9 @@
 #' @param name \code{character}. A taxonomic name. Various taxonomic levels
 #'   are supported (e.g. species, genus, family). NULL can also be supplied
 #'   which will skip the taxonomic filtering of the PhyloPic database.
+#' @param img A [Picture][grImport2::Picture-class] or png array object, e.g.,
+#'   from using [get_phylopic()]. If supplied, `name` and `n` are ignored. 
+#'   Defaults to NULL.
 #' @param n \code{numeric}. How many uuids should be returned? Depending on
 #'   the requested `name`, multiple silhouettes might exist. If `n` exceeds
 #'   the number of available images, all available uuids will be returned.
@@ -26,7 +29,19 @@
 #' @examples
 #' uuid <- get_uuid(name = "Acropora cervicornis")
 #' uuid <- get_uuid(name = "Dinosauria", n = 5, url = TRUE)
-get_uuid <- function(name = NULL, n = 1, url = FALSE) {
+get_uuid <- function(name = NULL, img = NULL, n = 1, url = FALSE) {
+  # Handle img -----------------------------------------------------------
+  if (!is.null(img)) {
+    if (is.null(attr(img, "uuid"))) {
+      stop("uuid not available. Check `img` is from get_phylopic.")
+    }
+    if (url) {
+      uuid <- attr(img, "url")
+    } else {
+      uuid <- attr(img, "uuid")
+    }
+    return(uuid)
+  }
   # Error handling -------------------------------------------------------
   if (!is.null(name) && !is.character(name)) {
     stop("`name` should be `NULL` or of class character.")

--- a/man/get_attribution.Rd
+++ b/man/get_attribution.Rd
@@ -4,11 +4,15 @@
 \alias{get_attribution}
 \title{Get PhyloPic attribution data}
 \usage{
-get_attribution(uuid = NULL, text = FALSE)
+get_attribution(uuid = NULL, img = NULL, text = FALSE)
 }
 \arguments{
 \item{uuid}{\code{character}. A vector of valid uuid(s) for PhyloPic
 silhouette(s) such as that returned by \code{\link[=get_uuid]{get_uuid()}} or \code{\link[=pick_phylopic]{pick_phylopic()}}.}
+
+\item{img}{A \link[grImport2:Picture-class]{Picture} or png array object, e.g.,
+from using \code{\link[=get_phylopic]{get_phylopic()}}. If supplied, \code{uuid} is ignored. Defaults to
+NULL.}
 
 \item{text}{\code{logical}. Should attribution information be returned as
 a text paragraph? Defaults to \code{FALSE}.}

--- a/man/get_attribution.Rd
+++ b/man/get_attribution.Rd
@@ -10,9 +10,9 @@ get_attribution(uuid = NULL, img = NULL, text = FALSE)
 \item{uuid}{\code{character}. A vector of valid uuid(s) for PhyloPic
 silhouette(s) such as that returned by \code{\link[=get_uuid]{get_uuid()}} or \code{\link[=pick_phylopic]{pick_phylopic()}}.}
 
-\item{img}{A \link[grImport2:Picture-class]{Picture} or png array object, e.g.,
-from using \code{\link[=get_phylopic]{get_phylopic()}}. If supplied, \code{uuid} is ignored. Defaults to
-NULL.}
+\item{img}{A \link[grImport2:Picture-class]{Picture} or png array object from
+\code{\link[=get_phylopic]{get_phylopic()}}. A list of these objects can also be supplied. If \code{img}
+is supplied, \code{uuid} is ignored. Defaults to NULL.}
 
 \item{text}{\code{logical}. Should attribution information be returned as
 a text paragraph? Defaults to \code{FALSE}.}

--- a/man/get_uuid.Rd
+++ b/man/get_uuid.Rd
@@ -11,9 +11,9 @@ get_uuid(name = NULL, img = NULL, n = 1, url = FALSE)
 are supported (e.g. species, genus, family). NULL can also be supplied
 which will skip the taxonomic filtering of the PhyloPic database.}
 
-\item{img}{A \link[grImport2:Picture-class]{Picture} or png array object, e.g.,
-from using \code{\link[=get_phylopic]{get_phylopic()}}. If supplied, \code{name} and \code{n} are ignored.
-Defaults to NULL.}
+\item{img}{A \link[grImport2:Picture-class]{Picture} or png array object from
+\code{\link[=get_phylopic]{get_phylopic()}}. A list of these objects can also be supplied. If \code{img}
+is supplied, \code{name} and \code{n} are ignored. Defaults to NULL.}
 
 \item{n}{\code{numeric}. How many uuids should be returned? Depending on
 the requested \code{name}, multiple silhouettes might exist. If \code{n} exceeds

--- a/man/get_uuid.Rd
+++ b/man/get_uuid.Rd
@@ -4,12 +4,16 @@
 \alias{get_uuid}
 \title{Get a PhyloPic uuid}
 \usage{
-get_uuid(name = NULL, n = 1, url = FALSE)
+get_uuid(name = NULL, img = NULL, n = 1, url = FALSE)
 }
 \arguments{
 \item{name}{\code{character}. A taxonomic name. Various taxonomic levels
 are supported (e.g. species, genus, family). NULL can also be supplied
 which will skip the taxonomic filtering of the PhyloPic database.}
+
+\item{img}{A \link[grImport2:Picture-class]{Picture} or png array object, e.g.,
+from using \code{\link[=get_phylopic]{get_phylopic()}}. If supplied, \code{name} and \code{n} are ignored.
+Defaults to NULL.}
 
 \item{n}{\code{numeric}. How many uuids should be returned? Depending on
 the requested \code{name}, multiple silhouettes might exist. If \code{n} exceeds

--- a/tests/testthat/test-get_attribution.R
+++ b/tests/testthat/test-get_attribution.R
@@ -8,9 +8,14 @@ test_that("get_attribution works", {
   # Expect equal
   uuid <- get_uuid(name = "Scleractinia", n = 5)
   expect_equal(length(get_attribution(uuid = uuid)), 5)
+  expect_message(get_attribution(uuid = uuid, text = TRUE))
+  # Check img arg
+  img <- get_phylopic(uuid = uuid[1])
+  expect_true(is.list(get_attribution(img = img)))
 
   # Expect error
   expect_error(get_attribution(uuid = NULL))
   expect_error(get_attribution(uuid = 1))
   expect_error(get_attribution(uuid = uuid, text = 1))
+  expect_error(get_attribution(img = 1))
 })

--- a/tests/testthat/test-get_uuid.R
+++ b/tests/testthat/test-get_uuid.R
@@ -6,10 +6,15 @@ test_that("get_uuid works", {
   expect_true(is.character(get_uuid(name = "Acropora", n = 1, url = TRUE)))
   expect_true(length(get_uuid(name = NULL, n = 100)) == 100)
   expect_true(length(get_uuid(name = NULL, n = 100, url = TRUE)) == 100)
+  uuid <- get_uuid(name = "Scleractinia")
+  img <- get_phylopic(uuid = uuid)
+  expect_equal(length(get_uuid(img = img)), 1)
+  expect_equal(length(get_uuid(img = img, url = TRUE)), 1)
   # Expect warnings
   expect_warning(is.character(get_uuid(name = "Acropora", n = 50, url = TRUE)))
   # Expect errors
   expect_error(get_uuid(name = 1))
   expect_error(get_uuid(name = "Acropora cervicornis", url = 1))
   expect_error(get_uuid(name = "Acropora cervicornis", n = "5"))
+  expect_error(get_uuid(img = "5d646d5a-b2dd-49cd-b450-4132827ef25e"))
 })


### PR DESCRIPTION
This PR adds an `img` argument to `get_uuid` and `get_attribution`. This will allow users to supply objects returned from `get_phylopic` (as well as lists of these objects) to get uuid and attribution data for the specific image. 