### PR TITLE
Add an example where silhouette is used for annotation

### DIFF
--- a/vignettes/b-advanced-ggplot.Rmd
+++ b/vignettes/b-advanced-ggplot.Rmd
@@ -67,7 +67,7 @@ ggplot(penguins_subset) +
   theme_bw(base_size = 15)
 ```
 
-That's a nice basic plot! But you know what would make it nicer? If we added a penguin silhouette to the plot. Sadly, we don't have a different silhouette for each species (although we could make one...), so let's just go with putting a single silhouette in the top panel. We'll use the `geom_phylopic()` function, which will require us to make a data frame. Note that the `x` and `y` aesthetics specify the center of the silhouette, and the `size` argument specifies how tall the silhouette is in the units of the y-axis. Also note that we need to wrap the penguin image in a `list()` call to make it a repeatable object
+That's a nice basic plot! But you know what would make it nicer? If we added a penguin silhouette to the plot. Sadly, we don't have a different silhouette for each species (although we could make one...), so let's just go with putting a single silhouette in the top panel. We'll use the `geom_phylopic()` function, which will require us to make a `data.frame`. Note that the `x` and `y` aesthetics specify the center of the silhouette, and the `size` argument specifies how tall the silhouette is in the units of the y-axis. Also note that we need to wrap the penguin image in a `list()` call to make it a repeatable object
 
 ```{r}
 silhouette_df <- data.frame(x = 59, y = 215, species = "Adelie")

--- a/vignettes/b-advanced-ggplot.Rmd
+++ b/vignettes/b-advanced-ggplot.Rmd
@@ -67,7 +67,20 @@ ggplot(penguins_subset) +
   theme_bw(base_size = 15)
 ```
 
-That's a nice basic plot! But you know what would make it nicer? If we used little penguins instead of points! To do that, we can use the `geom_phylopic()` function instead of the `geom_point()` function. Note that we need to wrap the penguin image in a `list()` call to make it a repeatable object (in this case, we want to use the same image for each x-y pair):
+That's a nice basic plot! But you know what would make it nicer? If we added a penguin silhouette to the plot. Sadly, we don't have a different silhouette for each species (although we could make one...), so let's just go with putting a single silhouette in the top panel. We'll use the `geom_phylopic()` function, which will require us to make a data frame. Note that the `x` and `y` aesthetics specify the center of the silhouette, and the `size` argument specifies how tall the silhouette is in the units of the y-axis. Also note that we need to wrap the penguin image in a `list()` call to make it a repeatable object
+
+```{r}
+silhouette_df <- data.frame(x = 59, y = 215, species = "Adelie")
+ggplot(penguins_subset) +
+  geom_point(aes(x = bill_length_mm, y = flipper_length_mm)) +
+  geom_phylopic(data = silhouette_df, aes(x = x, y = y), size = 30,
+                img = list(penguin_rot)) +
+  labs(x = "Bill length (mm)", y = "Flipper length (mm)") +
+  facet_wrap(~species, ncol = 1) +
+  theme_bw(base_size = 15)
+```
+
+Isn't that nifty! We can go a step further, though. What if we used little penguins instead of points?! To do that, we can use the `geom_phylopic()` function instead of the `geom_point()` function (in this case, we want to use the same image for each x-y pair):
 
 ```{r}
 ggplot(penguins_subset) +

--- a/vignettes/c-advanced-base.Rmd
+++ b/vignettes/c-advanced-base.Rmd
@@ -81,7 +81,25 @@ for (i in seq_along(species_split)) {
 }
 ```
 
-That's a nice basic plot! But you know what would make it nicer? If we used little penguins instead of points! To do that, we can use the `add_phylopic_base()` function. In this case, we'll specify `img = penguin_rot` since we want to use the same image for each x-y pair:
+That's a nice basic plot! But you know what would make it nicer? If we added a penguin silhouette to the plot. Sadly, we don't have a different silhouette for each species (although we could make one...), so let's just go with putting a single silhouette in the top panel. To do that, we can use the `add_phylopic_base()` function. Note that the `x` and `y` arguments specify the center of the silhouette, and the `ysize` argument specifies how tall the silhouette is in the units of the y-axis.
+
+```{r}
+# Set up the plot area
+par(mfrow = c(3, 1), mar = c(4, 4, 2, 1))
+
+# Loop over the species and create a plot for each one
+for (i in seq_along(species_split)) {
+  species_data <- species_split[[i]]
+  plot(x = species_data$bill_length_mm, y = species_data$flipper_length_mm,
+       xlab = "Bill length (mm)", ylab = "Flipper length (mm)",
+       main = names(species_split)[i],
+       xlim = range(penguins_subset$bill_length_mm, na.rm = TRUE),
+       ylim = range(penguins_subset$flipper_length_mm, na.rm = TRUE))
+  if (i == 1) add_phylopic_base(img = penguin_rot, x = 59, y = 215, ysize = 30)
+}
+```
+
+Isn't that nifty! We can go a step further, though. What if we used little penguins instead of points?! To do that, we can once again use the `add_phylopic_base()` function. In this case, we can again specify `img = penguin_rot` since we want to use the same image for each x-y pair:
 
 ```{r}
 # Set up the plot area


### PR DESCRIPTION
This adds another step to the penguins example in the vignettes to show how silhouettes can be used in an annotation manner (rather than replacing existing data points, etc).

Fixes #74.